### PR TITLE
fixing s3 for who_ambient_air_quality quak

### DIFF
--- a/dbt_demo/models/sources.yml
+++ b/dbt_demo/models/sources.yml
@@ -3,7 +3,7 @@ version: 2
 sources:
   - name: external_source
     meta:
-      external_location: "s3://us-prd-motherduck-open-datasets/parquet/who_ambient_air_quality/{name}.parquet"
+      external_location: "s3://us-prd-motherduck-open-datasets/who_ambient_air_quality/parquet/{name}.parquet"
     tables:
       - name: who_ambient_air_quality_database_version_v6_april_2023
 


### PR DESCRIPTION
Hi Mehdi, just watched your video on dbt duckdb brilliant job.

I had one issue when doing this tutorial with the s3 location which seems to have changed.

When running dbt i was getting this error:

<img width="1472" alt="dbt-duckdb-tutorial-issue-s3-path" src="https://github.com/mehd-io/dbt-duckdb-tutorial/assets/24627926/2bfc45b3-85ab-4abf-9f30-4e66399684cc">

I was able to find the updated path by querying your public s3 bucket.

Have simply changed the path and its all working.

p.s. i love devcontainers. I also ran across another duckdb project using devcontainers over in: https://github.com/dbt-labs/jaffle-shop-template which is also brilliant.
